### PR TITLE
Changed parseInt to parseFloat

### DIFF
--- a/Experiments/Live Train Rendering Experiment/OSM Test.html
+++ b/Experiments/Live Train Rendering Experiment/OSM Test.html
@@ -60,11 +60,20 @@
                 console.log("XML:", xml);
                 console.log("json:", json);
 
-                console.log(json.objTrainPositions)
+                console.log("json.objTrainPositions:")
+                console.log(json.objTrainPositions);
                 for (let train of json.objTrainPositions) {
                     console.warn("[LAT THEN LONG]", train.TrainLatitude['#text'], train.TrainLongitude['#text'])
+                
+                    //casting json string coordinates to a float
+                    let trainLat = parseFloat(train.TrainLatitude['#text']);
+                    let trainLong = parseFloat(train.TrainLongitude['#text']);
+                    // console.warn("Parsed Lat/Long: " + trainLat + " , " + trainLong);
 
-                    L.marker([parseInt(train.TrainLatitude['#text']), parseInt(train.TrainLongitude['#text'])]).addTo(map)
+                    //check for funky coordinates from api, as it can be 0,0 at times
+                    if ((trainLat, trainLong) === (0, 0)) continue;
+
+                    L.marker([trainLat, trainLong]).addTo(map)
                         .bindPopup(train.PublicMessage['#text']);
                     //, {icon: bus_icon}
                 }
@@ -113,6 +122,10 @@
 
         return obj;
     }
+
+
+    //Traffic layer
+
     </script>
 </body>
 


### PR DESCRIPTION
1. parseInt was rounding latitude and longitude to a whole number, parseFloat keeps them at their precise decimal value.
2. Checked for (0 , 0) lat/long values that were sometimes coming from the api by making the loop "continue" upon coming across such a value (I don't think Irish Rail is operating off the west coast of Africa lmao).

3. End of <script>: Added a place where traffic data implementation may go.